### PR TITLE
Updating to v-0.2.1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,12 @@
-Version 0.2.0 (April 21, 2021)
+Version 0.2.1 (April 30, 2021)
+-------------------------------
+* Option to display task-description as popover in collapsed view is now configurable
+ * Currently only from the custom project-settings!
+* Option to display latest comment as popover in collapsed view is now configurable
+  * Currently only from the custom project-settings!
+  * In fact for now it's not showing the latest comment, but it is rather a copy of the same link as in expanded view
+
+Version 0.2.0 (April 28, 2021)
 -------------------------------
 * Preserve the time(of the old due-date) when calculating the new due-date
 * Move Popover-Icon for the description to the left (to avoid overflow-issues with title-div)

--- a/Controller/ProjectSettingsController.php
+++ b/Controller/ProjectSettingsController.php
@@ -29,6 +29,8 @@ class ProjectSettingsController extends BaseController
                 'ACO_show_push_duebtn_taskview' => $this->projectMetadataModel->get($project['id'], 'ACO_show_push_duebtn_taskview', $this->helper->AdvancedCardOptionsHelper->ACO_defaults['ACO_show_push_duebtn_taskview']),
                 'ACO_remove_due_date'           => $this->projectMetadataModel->get($project['id'], 'ACO_remove_due_date', $this->helper->AdvancedCardOptionsHelper->ACO_defaults['ACO_remove_due_date']),
                 'ACO_create_due_date'           => $this->projectMetadataModel->get($project['id'], 'ACO_create_due_date', $this->helper->AdvancedCardOptionsHelper->ACO_defaults['ACO_create_due_date']),
+                'ACO_collapsed_description'     => $this->projectMetadataModel->get($project['id'], 'ACO_collapsed_description', $this->helper->AdvancedCardOptionsHelper->ACO_defaults['ACO_collapsed_description']),
+                'ACO_collapsed_latest_comment'  => $this->projectMetadataModel->get($project['id'], 'ACO_collapsed_latest_comment', $this->helper->AdvancedCardOptionsHelper->ACO_defaults['ACO_collapsed_latest_comment']),
                 'project_id' => $_REQUEST['project_id'],
             ),
             'errors' => $errors,
@@ -54,6 +56,8 @@ class ProjectSettingsController extends BaseController
         $this->projectMetadataModel->save($project['id'], array('ACO_show_push_duebtn_taskview' => isset($values["ACO_show_push_duebtn_taskview"]) ? $values["ACO_show_push_duebtn_taskview"] : 0 ));
         $this->projectMetadataModel->save($project['id'], array('ACO_remove_due_date' => isset($values["ACO_remove_due_date"]) ? $values["ACO_remove_due_date"] : 0 ));
         $this->projectMetadataModel->save($project['id'], array('ACO_create_due_date' => isset($values["ACO_create_due_date"]) ? $values["ACO_create_due_date"] : 0 ));
+        $this->projectMetadataModel->save($project['id'], array('ACO_collapsed_description' => isset($values["ACO_collapsed_description"]) ? $values["ACO_collapsed_description"] : 0 ));
+        $this->projectMetadataModel->save($project['id'], array('ACO_collapsed_latest_comment' => isset($values["ACO_collapsed_latest_comment"]) ? $values["ACO_collapsed_latest_comment"] : 0 ));
 
 	    return $this->show($values, $errors);
     }

--- a/Helper/AdvancedCardOptionsHelper.php
+++ b/Helper/AdvancedCardOptionsHelper.php
@@ -29,6 +29,8 @@ class AdvancedCardOptionsHelper extends TaskHelper
         'ACO_show_push_duebtn_taskview' =>0,
         'ACO_remove_due_date' => 0,
         'ACO_create_due_date' => 0,
+        'ACO_collapsed_description' => 0,
+        'ACO_collapsed_latest_comment' => 0,
     );
 
 

--- a/Plugin.php
+++ b/Plugin.php
@@ -49,7 +49,7 @@ class Plugin extends Base
 
     public function getPluginVersion()
     {
-        return '0.2.0';
+        return '0.2.1';
     }
 
     public function getPluginHomepage()

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Allows advanced control over the appearance _(and options)_ of the task-cards in
 
 #### List of planned features
 - [x] Allow to view the task-description as a mouseover-popup in collapsed view.
-  - Still hardcoded but moved to the left to avoid overflow-issues with the title-DIV
-- [ ] Allow to view the latest comment in expanded view _(and limit the number of words to display on the card)_
-- [ ] Allow to view the latest comment as a mouseover-popup in collapsed and/or expanded view.
+  [ ] Allow to view the latest comment in expanded view _(and limit the number of words to display on the card)_
+- [x] Allow to view the latest comment as a mouseover-popup in collapsed and/or expanded view.
+  - For now just copied the comments-links from the expanded to collapsed view
 - [ ] Allow to display tags and/or category in collapsed view.
 - [ ] Allow to view the due-date in collapsed view.
 - [x] Add up to 3 buttons to push the due-date of the task.

--- a/Template/board/task_footer.php
+++ b/Template/board/task_footer.php
@@ -1,8 +1,8 @@
 <?php
 // Get the configuration for the project / task
 $ACO_initialize = $this->helper->AdvancedCardOptionsHelper->Initialize($project['id']);
-$ACO_push_due_days = $this->helper->AdvancedCardOptionsHelper->getPushDueDays();
-$ACO_remove_due_date = $this->helper->AdvancedCardOptionsHelper->getParameter('ACO_remove_due_date');
+$ACO_push_due_days          = $this->helper->AdvancedCardOptionsHelper->getPushDueDays();
+$ACO_remove_due_date        = $this->helper->AdvancedCardOptionsHelper->getParameter('ACO_remove_due_date');
 
 // Figure out if we are supposed to display ANY icons related to pushing the due date (because these will be wrapped within STRONG square brackets)
 if ( array_sum($ACO_push_due_days) === 1 ){

--- a/Template/board/task_private.php
+++ b/Template/board/task_private.php
@@ -1,3 +1,12 @@
+<?php
+// Get the configuration for the project / task
+$ACO_initialize = $this->helper->AdvancedCardOptionsHelper->Initialize($project['id']);
+$ACO_push_due_days              = $this->helper->AdvancedCardOptionsHelper->getPushDueDays();
+$ACO_remove_due_date            = $this->helper->AdvancedCardOptionsHelper->getParameter('ACO_remove_due_date');
+$ACO_collapsed_description      = $this->helper->AdvancedCardOptionsHelper->getParameter('ACO_collapsed_description');
+$ACO_collapsed_latest_comment   = $this->helper->AdvancedCardOptionsHelper->getParameter('ACO_collapsed_latest_comment');
+
+?>
 <div class="
         task-board
         <?= $task['is_draggable'] ? 'draggable-item ' : '' ?>
@@ -26,11 +35,33 @@
                 <strong><?= '#'.$task['id'] ?></strong>
             <?php endif ?>
 
-            <!-- fa-file-o = No DESC/COMMENT // fa-file-text-o = DESC only / fa-comment-o = COMMENT only / fa-file-txt = DESC + COMMENT / -->
-            <?php if (! empty($task['description'])): ?>
-                <?= $this->app->tooltipLink('<i class="fa fa-file-text-o"></i>', $this->url->href('BoardTooltipController', 'description', array('task_id' => $task['id'], 'project_id' => $task['project_id']))) ?>
-            <?php elseif (empty($task['description'])): ?>
-                <span class="aco_dimmed"><i class="fa fa-file-o"></i></span>
+            <?php if ($ACO_collapsed_description): ?>
+                <!-- fa-file-o = No DESC/COMMENT // fa-file-text-o = DESC only / fa-comment-o = COMMENT only / fa-file-txt = DESC + COMMENT / -->
+                <?php if (! empty($task['description'])): ?>
+                    <?= $this->app->tooltipLink('<i class="fa fa-file-text-o"></i>', $this->url->href('BoardTooltipController', 'description', array('task_id' => $task['id'], 'project_id' => $task['project_id']))) ?>
+                <?php elseif (empty($task['description'])): ?>
+                    <span class="aco_dimmed"><i class="fa fa-file-o"></i></span>
+                <?php endif ?>
+            <?php endif ?>
+
+            <?php if ($ACO_collapsed_latest_comment): ?>
+                <?php if ($task['nb_comments'] > 0): ?>
+                    <?php if ($not_editable): ?>
+                        <?php $aria_label = $task['nb_comments'] == 1 ? t('%d comment', $task['nb_comments']) : t('%d comments', $task['nb_comments']); ?>
+                        <span title="<?= $aria_label ?>" role="img" aria-label="<?= $aria_label ?>"><i class="fa fa-comments-o"></i>&nbsp;<?= $task['nb_comments'] ?></span>
+                    <?php else: ?>
+                        <?= $this->modal->medium(
+                            'comments-o',
+                            $task['nb_comments'],
+                            'CommentListController',
+                            'show',
+                            array('task_id' => $task['id'], 'project_id' => $task['project_id']),
+                            $task['nb_comments'] == 1 ? t('%d comment', $task['nb_comments']) : t('%d comments', $task['nb_comments'])
+                        ) ?>
+                    <?php endif ?>
+                <?php else: ?>
+                    <span class="aco_dimmed"><i class="fa fa-comments-o"></i></span>
+                <?php endif ?>
             <?php endif ?>
 
             <?php if (! empty($task['assignee_username'])): ?>

--- a/Template/project/advanced_card_options.php
+++ b/Template/project/advanced_card_options.php
@@ -19,6 +19,13 @@
     </fieldset>
 
     <fieldset>
+        <legend><?= t('Additional information') ?></legend>
+            <legend><?= t('Display additional information in card-view"') ?></legend>
+            <?= $this->form->checkbox('ACO_collapsed_description', t('Show description(popover) in collapsed card-view'), 1, $values['ACO_collapsed_description'] == 1) ?>
+            <?= $this->form->checkbox('ACO_collapsed_latest_comment', t('Show latest comment(popover) in collapsed card-view'), 1, $values['ACO_collapsed_latest_comment'] == 1) ?>
+    </fieldset>
+
+    <fieldset>
         <legend><?= t('Buttons to change the due-date') ?></legend>
         <?= t('Number of days to push the due-date:'); ?>
         <p class="form-help"><?= t('Leave blank or set to 0 to disable button') ?></p>


### PR DESCRIPTION
* Option to display task-description as popover in collapsed view is now configurable
  * Currently only from the custom project-settings!
* Option to display latest comment as popover in collapsed view is now configurable
  * Currently only from the custom project-settings!
  * In fact for now it's not showing the latest comment, but it is rather a copy of the same link as in expanded view